### PR TITLE
feat(enhancement): add delete and persistent cart after refresh functionality; can click delete for one item only

### DIFF
--- a/client/components/CartList.js
+++ b/client/components/CartList.js
@@ -1,19 +1,28 @@
 import React from 'react'
 import {connect} from 'react-redux'
+import {removeItemToOrder, getWholeCart} from '../store/order'
 
 class CartList extends React.Component {
+  componentDidMount() {
+    this.props.getWholeCart()
+  }
 
   render() {
-    let productCartArray = Array.from(this.props.products);
-    let arrayRender = productCartArray.map(item => { return <li key={item.id} >{"NAME: " + item.name}: {"PRICE: " + item.price}</li>})
+    let productCartArray = Array.from(this.props.products)
+    let arrayRender = productCartArray.map(item => {
+      return (
+        <li key={item.id}>
+          {'NAME: ' + item.name}: {'PRICE: ' + item.price}{' '}
+          <button type="button" onClick={(()=> this.props.removeItemToOrder(item.id))}>x</button>
+        </li>
+      )
+    })
 
     return (
-        <div>
-          <h1>Cart:</h1>
-          <ul>
-            {arrayRender}
-          </ul>
-        </div>
+      <div>
+        <h1>Cart:</h1>
+        <ul>{arrayRender}</ul>
+      </div>
     )
   }
 }
@@ -22,7 +31,9 @@ const mapStatetoProps = state => ({
   products: state.order.cart
 })
 
-export default connect(mapStatetoProps)(CartList)
+const mapDispatchToProps = dispatch => ({
+  removeItemToOrder: (id) => dispatch(removeItemToOrder(id)),
+  getWholeCart: () => dispatch(getWholeCart())
+})
 
-
-
+export default connect(mapStatetoProps, mapDispatchToProps)(CartList)

--- a/client/store/order.js
+++ b/client/store/order.js
@@ -1,23 +1,44 @@
 import axios from 'axios'
 
-const ADD_CART_ITEM = 'ADD_CART_ITEM'
+const UPDATE_CART = 'UPDATE_CART'
+
 
 const defaultState = {cart: []}
 
-const addCart = (cart) => ({type: ADD_CART_ITEM, cart })
+const updateCart = (cart) => ({type: UPDATE_CART, cart })
 
 export const addItemToOrder = (id) => async dispatch => {
   try {
     const res = await axios.get(`/api/orders/add/${id}`)
-    dispatch(addCart(res.data))
+    dispatch(updateCart(res.data))
   } catch (err) {
+    console.error(err)
+  }
+}
+
+export const getWholeCart = () => async dispatch => {
+  try {
+    const res = await axios.get('/api/orders')
+    dispatch(updateCart(res.data))
+  }
+  catch(err) {
+    console.error(err)
+  }
+}
+
+export const removeItemToOrder = (id) => async dispatch => {
+  try {
+    const res = await axios.delete(`/api/orders/remove/${id}`)
+    dispatch(updateCart(res.data))
+  }
+  catch(err) {
     console.error(err)
   }
 }
 
 export default function(state = defaultState, action) {
   switch (action.type) {
-    case ADD_CART_ITEM:
+    case UPDATE_CART:
       return {...state, cart: action.cart}
     default:
       return state

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -2,15 +2,33 @@ const router = require('express').Router()
 const {Order, Product, OrderProduct} = require('../db/models')
 module.exports = router
 
-router.get('/add/:id', async (req, res) => {
+router.get('/', (req, res, next) => {
   if (!req.session.cart) {
     req.session.cart = [];
   }
-  const product = await Product.findById(req.params.id);
-  req.session.cart.push(product)
   res.json(req.session.cart)
 })
 
+router.delete('/remove/:id', (req, res, next) => {
+  req.session.cart = req.session.cart.filter(eachItem => {
+    return +eachItem.id !== +req.params.id
+  })
+  res.json(req.session.cart)
+})
+
+router.get('/add/:id', async (req, res, next) => {
+  try {
+    if (!req.session.cart) {
+      req.session.cart = [];
+    }
+    const product = await Product.findById(req.params.id);
+    req.session.cart.push(product)
+    res.json(req.session.cart)
+  }
+  catch(err) {
+    next(err)
+  }
+})
 
 router.put('/', async (req, res, next) => {
     try {


### PR DESCRIPTION
### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

feat(enhancement): add delete and persistent cart after refresh functionality; can click delete for one item only. location is within server/api/orders.js and client/store/order.js